### PR TITLE
🐛 [Fix] ChatRoom오타수정, 콘솔 map key에러 , 라우팅 에러 해결

### DIFF
--- a/chatApp/renderer/components/ChatList.tsx
+++ b/chatApp/renderer/components/ChatList.tsx
@@ -15,7 +15,7 @@ import { isModalOpen } from "../recoil/authAtom";
 import { useRecoilState } from "recoil";
 import { useAuthState } from "react-firebase-hooks/auth";
 
-function ChatRoom() {
+function ChatList() {
   const [userName, setUserName] = useState<string>("");
 
   const [user] = useCollection(collection(db, "userInfo"));
@@ -112,4 +112,4 @@ function ChatRoom() {
   );
 }
 
-export default ChatRoom;
+export default ChatList;

--- a/chatApp/renderer/components/ChatList.tsx
+++ b/chatApp/renderer/components/ChatList.tsx
@@ -98,11 +98,8 @@ function ChatRoom() {
             .map((chatRoom, idx) => {
               return (
                 // 채팅방 아이디로 구분하여 페이지 라우팅
-                <Link href={`/chatRoom/${chatRoom.id}`}>
-                  <div
-                    key={idx}
-                    className="flex justify-start items-center bg-white shadow-lg cursor-pointer	 w-full h-10 px-4 mb-2"
-                  >
+                <Link key={idx} href={`/chatRoom/${chatRoom.id}`}>
+                  <div className="flex justify-start items-center bg-white shadow-lg cursor-pointer	 w-full h-10 px-4 mb-2">
                     <ChatIcon />
                     <p className="pl-2">{chatRoom.users}</p>
                   </div>

--- a/chatApp/renderer/components/ChatRoom.tsx
+++ b/chatApp/renderer/components/ChatRoom.tsx
@@ -39,19 +39,18 @@ function ChatRoom() {
         <div className="bg-btnBg  mx-4 text-white font-bold py-2 px-4 rounded leading-snug uppercase  shadow-md  hover:shadow-lg  transition duration-150 ease-in-out w-fit max-w-10 ">
           <text>테스트메세지 상대</text>
         </div>
-        {chatRoom.map((chatRoom, idx) => {
-          return (
-            <div className="flex justify-end">
-              <p key={chatRoom.name}>{chatRoom.name}</p>
-              <div
-                key={idx}
-                className="bg-white  mx-4 text-black font-bold py-2 px-4 rounded leading-snug uppercase  shadow-md  hover:shadow-lg  transition duration-150 ease-in-out w-fit max-w-10 "
-              >
-                <p key={chatRoom.name}>{chatRoom.message}</p>
+        {chatRoom &&
+          chatRoom.map((chatRoom) => {
+            return (
+              <div key={chatRoom.id} className="flex justify-end">
+                <p>{chatRoom.name}</p>
+
+                <div className="bg-white  mx-4 text-black font-bold py-2 px-4 rounded leading-snug uppercase  shadow-md  hover:shadow-lg  transition duration-150 ease-in-out w-fit max-w-10 ">
+                  <p>{chatRoom.message}</p>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
       </div>
     </div>
   );

--- a/chatApp/renderer/components/ChatRoom.tsx
+++ b/chatApp/renderer/components/ChatRoom.tsx
@@ -37,7 +37,7 @@ function ChatRoom() {
       <div className="p-2 mb-2"></div>
       <div className="scrollbar-thin h-[300px] scrollbar-thumb-poinPink scrollbar-track-mainBg overflow-y-scroll scrollbar-thumb-rounded-full scrollbar-track-rounded-full">
         <div className="bg-btnBg  mx-4 text-white font-bold py-2 px-4 rounded leading-snug uppercase  shadow-md  hover:shadow-lg  transition duration-150 ease-in-out w-fit max-w-10 ">
-          <text>테스트메세지 상대</text>
+          <p>테스트메세지 상대</p>
         </div>
         {chatRoom &&
           chatRoom.map((chatRoom) => {

--- a/chatApp/renderer/components/HomeNavigation.tsx
+++ b/chatApp/renderer/components/HomeNavigation.tsx
@@ -8,6 +8,7 @@ import { isShowNav } from "../recoil/authAtom";
 import { useRecoilState } from "recoil";
 
 function HomeNavigation() {
+  const router = useRouter();
   const [isShowHomeNav, setIsShoHomeNav] = useRecoilState(isShowNav);
 
   const logOut = async () => {
@@ -22,8 +23,6 @@ function HomeNavigation() {
   const [userLocalStorage, setUserLocalStorage] = useState(null);
   useEffect(() => setUserLocalStorage(window.localStorage.user), []);
 
-  const router = useRouter();
-
   return (
     <>
       {userLocalStorage !== null && userLocalStorage ? (
@@ -34,15 +33,21 @@ function HomeNavigation() {
               <div className="ml-3">{userLocalStorage}</div>
             </div>
             <div>
-              <button className="mr-3 bg-btnBg hover:bg-poinPink text-white font-bold py-2 px-4 rounded">
-                <Link href="/chat">
-                  <a>채팅방목록</a>
-                </Link>
+              <button
+                onClick={() => {
+                  router.push("/chat");
+                }}
+                className="mr-3 bg-btnBg hover:bg-poinPink text-white font-bold py-2 px-4 rounded"
+              >
+                <a>채팅방목록</a>
               </button>
-              <button className="mr-3 bg-btnBg hover:bg-poinPink text-white font-bold py-2 px-4 rounded">
-                <Link href="/user">
-                  <a>친구</a>
-                </Link>
+              <button
+                onClick={() => {
+                  router.push("/user");
+                }}
+                className="mr-3 bg-btnBg hover:bg-poinPink text-white font-bold py-2 px-4 rounded"
+              >
+                <a>친구</a>
               </button>
             </div>
             <button

--- a/chatApp/renderer/components/UserList.tsx
+++ b/chatApp/renderer/components/UserList.tsx
@@ -35,7 +35,7 @@ function UserList() {
         <div className="w-full scrollbar-thin h-[400px] scrollbar-thumb-poinPink scrollbar-track-mainBg overflow-y-scroll scrollbar-thumb-rounded-full scrollbar-track-rounded-full">
           {user.map((user, idx) => {
             return (
-              <Link href={`/chatRoom/${user.id}`}>
+              <Link key={idx} href={`/chatRoom/${user.id}`}>
                 <div
                   key={idx}
                   className="flex shadow-lg justify-between items-center bg-white cursor-pointer	 w-full h-10 px-4 mb-2"


### PR DESCRIPTION
[구현사항]
![image](https://user-images.githubusercontent.com/99955022/216646608-f3eec8cc-730d-4080-8478-26eb90e1a423.png)
콘솔에서는 key가 필요한 요소가 ChatRoom에 있다 해서 수정했는데 아무리 수정해도 에러메세지가 사라지지 않았다.
그래서 혹시 몰라 map을 사용한 모든 곳을 확인 해 보니 사실 ChatList컴포넌트 안의 함수 이름을 ChatRoom으로 해 놓아서 계속 못찾았던 것이다.
컴포넌트 이름 수정하고 모든 map에 대한 key값을 부여해서 콘솔의 에러메세지를 해결했다

- 두 번 클릭해야 페이지 라우팅 되는 에러 해결
두 세번 클릭해야 라우팅이 되는 에러가 있었음
기존 링크 방식으로 라우팅 하던 것을 라우터로 변경 해 주었더니 해결 되었음
에러 관련 노션기록 https://antique-map-b03.notion.site/2023-02-03_-ce33e9a708204023990d8744bfa1c96e
